### PR TITLE
Update nalgebra to fix compilation error on Rust 1.40

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -191,7 +191,7 @@ dependencies = [
 
 [[package]]
 name = "nalgebra"
-version = "0.17.2"
+version = "0.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "alga 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -345,7 +345,7 @@ version = "0.1.0"
 dependencies = [
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossterm 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "nalgebra 0.17.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nalgebra 0.17.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "stl_io 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tobj 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -443,7 +443,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum libc 0.2.53 (registry+https://github.com/rust-lang/crates.io-index)" = "ec350a9417dfd244dc9a6c4a71e13895a4db6b92f0b106f07ebbc3f3bc580cee"
 "checksum libm 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "03c0bb6d5ce1b5cc6fd0578ec1cbc18c9d88b5b591a5c7c1d6c6175e266a0819"
 "checksum matrixmultiply 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dcfed72d871629daa12b25af198f110e8095d7650f5f4c61c5bac28364604f9b"
-"checksum nalgebra 0.17.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f76a29833cbba252d6799bcfd8e603610a2165a18b62c7f4307495d851c3d337"
+"checksum nalgebra 0.17.3 (registry+https://github.com/rust-lang/crates.io-index)" = "be539bb5e751c248d25c21c850b69105809306f367c35bf1daa8724f0cb786df"
 "checksum num-complex 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "107b9be86cd2481930688277b675b0114578227f034674726605b8a482d8baf8"
 "checksum num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0b3a5d7cc97d6d30d8b9bc8fa19bf45349ffe46241e8816f50f62f6d6aaabee1"
 "checksum rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"


### PR DESCRIPTION
In Rust 1.40 a future-compatibility-warning will become a hard error, which will cause the dependency `nalgebra v0.17.2` to no longer compile.
Reason: [Rust 2015: No longer downgrade NLL errors](https://github.com/rust-lang/rust/pull/64221)

```
rust-sloth$ cargo +nightly check
    Checking nalgebra v0.17.2
error[E0502]: cannot borrow `*self` as immutable because it is also borrowed as mutable
   --> /home/myname/.cargo/registry/src/github.com-1ecc6299db9ec823/nalgebra-0.17.2/src/base/cg.rs:297:44
    |
297 |                 self[(j, i)] += shift[j] * self[(D::dim() - 1, i)];
    |                 ---------------------------^^^^-------------------
    |                 |                          |
    |                 |                          immutable borrow occurs here
    |                 mutable borrow occurs here
    |                 mutable borrow later used here

error: aborting due to previous error

For more information about this error, try `rustc --explain E0502`.
error: could not compile `nalgebra`.

To learn more, run the command again with --verbose.
```

To fix this, I ran `cargo update --package nalgebra` to update it to `v0.17.3`.
(Just `cargo update` causes the terminal renderer to mess up...)

Btw, this project is amazing ^^
I've made a bash alias `pikachu` and I show it to basically every IT person I meet :)